### PR TITLE
Insert info about localStorage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Loading a page before injecting the scripts is solving these issues:
 - Error: `SECURITY_ERR: DOM Exception 18` because setting cookies is not
   allowed for `file://` URLs
 - Error: `access to the Indexed Database API is denied in this context`
+- localStorage being inaccessible.
 
 ## Compatibility
 


### PR DESCRIPTION
This info should probably be in the `mochify` README as well as here.  I'm sure using `localStorage` is a pretty common thing.

You cannot have code that accesses localStorage in tests that use `mochify --wd`.

For example (with mochify):
```javascript
describe('testing localStorage in min-webdriver browser', function () {
  it.only('ls', function() {
    try {
      console.log(localStorage);
    } catch(e) {
      console.log('localStorage access error: ', e)
    }

    try {
      console.log(window.localStorage);
    } catch(e) {
      console.log('window.localStorage access error: ', e)
    }
  })
});
```

Outputs:
```
./node_modules/.bin/mochify --wd
# firefox *:

  localStorage access error:  {}
window.localStorage access error:  {}

  .

  1 passing (6ms)
```

I found that if you run mochify with something like `mochify gobbedlygook --wd` it will leave the browser open.

If I try to access the `localStorage` object by merely typing `localStorage` into that browser's console, I get:

```
[Exception... "Component is not available"  nsresult: "0x80040111 (NS_ERROR_NOT_AVAILABLE)"  location: "JS frame :: debugger eval code :: <TOP_LEVEL> :: line 1"  data: no]
```

This issue is resolved by providing a page url.