### PR TITLE
Options to not close browser on finish and/or on error.

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -28,24 +28,32 @@ function pollLogs(context, callback) {
     script : 'window._webdriver_poll(arguments[0]);',
     args   : []
   }, function (err, res) {
-    if (err && context.closeOnError) {
-      close(context, function () {
+    if (err) {
+      if (context.closeOnError) {
+        close(context, function () {
+          callback(err);
+        });
+      } else {
         callback(err);
-      });
+      }
       return;
     }
     var match = res.value.match(/^WEBDRIVER_EXIT\(([0-9]+)\)$/m);
     if (match) {
       context.out.write(res.value.substring(0, match.index));
 
+      var localCallback = function () {
+        if (match[1] === '0') {
+          callback();
+        } else {
+          callback(new Error('Build failed: ' + match[1]));
+        }
+      };
+
       if (context.closeOnSuccess) {
-        close(context, function () {
-          if (match[1] === '0') {
-            callback();
-          } else {
-            callback(new Error('Build failed: ' + match[1]));
-          }
-        });
+        close(context, localCallback);
+      } else {
+        localCallback();
       }
       return;
     }
@@ -64,12 +72,18 @@ function execute(context, script, callback) {
     script : script,
     args   : []
   }, function (err) {
-    if (err && context.closeOnError) {
-      close(context, function () {
+
+    if (err) {
+      if (context.closeOnError) {
+        close(context, function () {
+          callback(err);
+        });
+      } else {
         callback(err);
-      });
+      }
       return;
     }
+
     setTimeout(function () {
       pollLogs(context, callback);
     }, 100);
@@ -93,10 +107,14 @@ function openUrl(context, script, callback) {
     request(context, 'POST', '/url', {
       url : url
     }, function (err) {
-      if (err && context.closeOnError) {
-        close(context, function () {
+      if (err) {
+        if (context.closeOnError) {
+          close(context, function () {
+            callback(err);
+          });
+        } else {
           callback(err);
-        });
+        }
         return;
       }
       execute(context, x.js, callback);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -38,7 +38,7 @@ function pollLogs(context, callback) {
     if (match) {
       context.out.write(res.value.substring(0, match.index));
 
-      if (context.closeOnFinish) {
+      if (context.closeOnSuccess) {
         close(context, function () {
           if (match[1] === '0') {
             callback();
@@ -156,7 +156,7 @@ function createContext(options, browser, out) {
     out           : out,
     sauceLabs     : options.sauceLabs,
     closeOnError  : options.closeOnError,
-    closeOnFinish : options.closeOnFinish
+    closeOnSuccess : options.closeOnSuccess
   };
 }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -28,7 +28,7 @@ function pollLogs(context, callback) {
     script : 'window._webdriver_poll(arguments[0]);',
     args   : []
   }, function (err, res) {
-    if (err) {
+    if (err && context.closeOnError) {
       close(context, function () {
         callback(err);
       });
@@ -38,13 +38,15 @@ function pollLogs(context, callback) {
     if (match) {
       context.out.write(res.value.substring(0, match.index));
 
-      close(context, function () {
-        if (match[1] === '0') {
-          callback();
-        } else {
-          callback(new Error('Build failed: ' + match[1]));
-        }
-      });
+      if (context.closeOnFinish) {
+        close(context, function () {
+          if (match[1] === '0') {
+            callback();
+          } else {
+            callback(new Error('Build failed: ' + match[1]));
+          }
+        });
+      }
       return;
     }
     if (context.out.write(res.value)) {
@@ -62,7 +64,7 @@ function execute(context, script, callback) {
     script : script,
     args   : []
   }, function (err) {
-    if (err) {
+    if (err && context.closeOnError) {
       close(context, function () {
         callback(err);
       });
@@ -91,7 +93,7 @@ function openUrl(context, script, callback) {
     request(context, 'POST', '/url', {
       url : url
     }, function (err) {
-      if (err) {
+      if (err && context.closeOnError) {
         close(context, function () {
           callback(err);
         });
@@ -132,7 +134,7 @@ function connectBrowser(context, callback) {
     request(context, 'POST', '/timeouts/async_script', {
       ms : context.timeout || 10000
     }, function (err) {
-      if (err) {
+      if (err && context.closeOnError) {
         close(context, function () {
           callback(err);
         });
@@ -145,14 +147,16 @@ function connectBrowser(context, callback) {
 
 function createContext(options, browser, out) {
   return {
-    hostname  : options.hostname,
-    port      : options.port,
-    url       : options.url,
-    timeout   : options.timeout,
-    basePath  : '/wd/hub',
-    browser   : browser,
-    out       : out,
-    sauceLabs : options.sauceLabs
+    hostname      : options.hostname,
+    port          : options.port,
+    url           : options.url,
+    timeout       : options.timeout,
+    basePath      : '/wd/hub',
+    browser       : browser,
+    out           : out,
+    sauceLabs     : options.sauceLabs,
+    closeOnError  : options.closeOnError,
+    closeOnFinish : options.closeOnFinish
   };
 }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -35,11 +35,13 @@ function loadOptions(fileName, key, options) {
 
 module.exports = function (opts) {
   var options = {
-    hostname : 'localhost',
-    port     : 4444,
-    browsers : [{
-      name   : 'chrome'
-    }]
+    hostname      : 'localhost',
+    port          : 4444,
+    browsers      : [{
+      name        : 'chrome'
+    }],
+    closeOnError  : true,
+    closeOnFinish : true
   };
 
   if (!loadOptions('.min-wd', null, options)) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -41,7 +41,7 @@ module.exports = function (opts) {
       name        : 'chrome'
     }],
     closeOnError  : true,
-    closeOnFinish : true
+    closeOnSuccess : true
   };
 
   if (!loadOptions('.min-wd', null, options)) {


### PR DESCRIPTION
I know in mantoni/mochify.js#77 you metioned `closeOnFailure`, but but `closeOnFinish` was easy to implement and I can foresee use cases for exploring problems.

As you mentioned on the other issue, this defaults to closing the browser when done, but if you set `closeOnFinish`/`closeOnError` option to `false`, it will leave browser open.

