### PR TITLE
Adds the support for sync polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ increase the timeout by adding a `timeout` property to your config:
 "timeout": 20000
 ```
 
+**Notice:** This option is not used if explicitly setting the `asyncPolling` option to `false`.
+
 ## API
 
 Use min-wd programatically with browserify like this:
@@ -127,6 +129,7 @@ b.plugin(minWd, { timeout : 0 });
   `true`, `ondemand.saucelabs.com` is used.
 - `port` the port to connect to. Defaults to `4444`. If `sauceLabs` is `true`,
   `80` is used.
+- `asyncPolling` whether to use async polling when looking for test results. Defaults to `true`.
 - `timeout` if a script does not respond to log polling calls for this amount
   of milliseconds, the test run is aborted. Defaults to 10 seconds.
 - `url` the URL to open in each browser. Defaults to no URL.
@@ -137,6 +140,11 @@ b.plugin(minWd, { timeout : 0 });
       `internet explorer`
     - `version` the browser version to launch. Use `*` for any.
     - `url` an optional URL to launch for this browser
+
+Some options are only considered depending on the `asyncPolling` value:
+
+  - `pollingInterval` sets the time interval between test log checks. Only apply if `asyncPolling` is `false`. Defaults to 1000 milliseconds.
+  - `timeout` option won't apply if `asyncPolling` is set to `false` because the test log is checked manually respecting `pollingInterval`.
 
 SauceLabs specific options that only apply if `sauceLabs` is set to `true`:
 
@@ -178,6 +186,12 @@ Loading a page before injecting the scripts is solving these issues:
   allowed for `file://` URLs
 - Error: `access to the Indexed Database API is denied in this context`
 - localStorage being inaccessible.
+
+#### Usage with Microsoft Edge browser
+
+For the time being, MS Edge currently doesn't support `asyncPolling` set to `true`.
+
+If you want to test with that browser you must set `asyncPolling` to `false`.
 
 ## Compatibility
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -32,6 +32,12 @@ window._webdriver_poll = function (callback) {
   }
 };
 
+window._webdriver_manualPoll = function () {
+  var str = logs.join('');
+  logs = [];
+  return str;
+};
+
 brout.on('out', push);
 brout.on('err', push);
 brout.on('exit', function (code) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -23,8 +23,16 @@ function close(context, callback) {
 }
 
 function pollLogs(context, callback) {
-  request(context, 'POST', '/execute_async', {
-    script : 'window._webdriver_poll(arguments[0]);',
+  var endpoint = context.asyncPolling ? '/execute_async' : '/execute';
+  var timeout = context.asyncPolling ? 0 : context.pollingInterval;
+  var script;
+  if (context.asyncPolling) {
+    script = 'window._webdriver_poll(arguments[0]);';
+  } else {
+    script = 'return window._webdriver_manualPoll();';
+  }
+  request(context, 'POST', endpoint, {
+    script : script,
     args   : []
   }, function (err, res) {
     if (err) {
@@ -71,10 +79,14 @@ function pollLogs(context, callback) {
       return;
     }
     if (context.out.write(res.value)) {
-      pollLogs(context, callback);
+      setTimeout(function () {
+        pollLogs(context, callback);
+      }, timeout);
     } else {
       context.out.once('drain', function () {
-        pollLogs(context, callback);
+        setTimeout(function () {
+          pollLogs(context, callback);
+        }, timeout);
       });
     }
   });
@@ -158,7 +170,7 @@ function connectBrowser(context, callback) {
       return;
     }
     context.basePath = context.basePath + '/session/' + res.sessionId;
-    if (context.timeout === 0) {
+    if (!context.asyncPolling || context.timeout === 0) {
       callback(null);
       return;
     }
@@ -181,6 +193,8 @@ function createContext(options, browser, out) {
     hostname      : options.hostname,
     port          : options.port,
     url           : options.url,
+    asyncPolling  : options.asyncPolling,
+    pollingInterval : options.pollingInterval,
     timeout       : options.timeout,
     basePath      : '/wd/hub',
     browser       : browser,

--- a/lib/options.js
+++ b/lib/options.js
@@ -40,6 +40,8 @@ module.exports = function (opts) {
     browsers      : [{
       name        : 'chrome'
     }],
+    asyncPolling : true,
+    pollingInterval : 1000,
     closeOnError  : true,
     closeOnSuccess : true
   };

--- a/lib/request.js
+++ b/lib/request.js
@@ -72,7 +72,7 @@ function request(context, method, path, json, callback) {
           && path === '/session') {
         var sessionId = res.headers.location;
         if (!sessionId) {
-          fail(context, options, 'Received HTTP status ' + res.statucCode
+          fail(context, options, 'Received HTTP status ' + res.statusCode
               + ' without location header', res.headers, body, callback);
           return;
         }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "brout": "^1.0",
     "listen": "^1.0",
     "resolve": "^1.0",
-    "saucelabs": "^0.1.1",
+    "saucelabs": "^1.0",
     "source-mapper": "^1.0",
     "through2": "^1.1"
   },


### PR DESCRIPTION
This PR adds handles the current problem we're having with MS Edge as discussed in #8.

The proposed solution I came up with is adding two new options: `asyncPolling` and `pollingInterval`.

The `asyncPolling` option actually is just a flag that determines if `min-webdriver` will use the default asynchronous polling method or the new synchronous workaround one.

For people not specifying this new option everything stays the same. If it is explicitly set to `false` then `min-webdriver` will avoid using the `execute_async` and `timeout/async_script` methods and stick with using just `execute` for both the test execution and test log checks.

The `pollingInterval` option is optional and just applies if `asyncPolling` is `false`. It determines the time interval in which test log checks occur.

Notice that `timeout` won't apply if `asyncPolling` is `false` because there is no timeout for test checks as it's synchronous polling and it will get what it can get. The session timeout still applies though as it prevents test suites from running forever.

The changes included in this PR enable support for the current MS Edge webdriver. I've tested with saucelabs and it works, also have done a bunch of other tests to certify it won't break other stuff.

Please test it further as we don't want this to break any existing behavior. Let me know if changes are needed.

Also included a fix for a typo in the `request.js` code and bumped the `saucelabs` dependency.
