### PR TITLE
Improved timeout configuration and periodically flush logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -119,13 +119,18 @@ If this is your use case, make sure to give [Mochify][] a try.
 
 ## Timeouts
 
-The default timeout for the log polling script is 10 seconds. If you have long
-running test cases that don't print anything for more than 10 seconds, you can
-increase the timeout by adding a `timeout` property to your config:
+[Webdriver's session timeouts](https://www.w3.org/TR/webdriver/#set-timeouts)
+are configurable with the `timeouts` property:
 
+```json
+"timeouts": {
+  "script": 10000,
+  "pageLoad": 2000,
+  "implicit": 1000
+}
 ```
-"timeout": 20000
-```
+
+By default only the `script` timeout is set to 10 seconds.
 
 **Notice:** This option is not used if explicitly setting the `asyncPolling`
 option to `false`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install min-wd
 
 Put a config file name `.min-wd` in your project directory:
 
-```
+```json
 {
   "hostname": "localhost",
   "port": 4444,
@@ -36,7 +36,7 @@ Put a config file name `.min-wd` in your project directory:
 
 You can also have the `.min-wd` file be loaded as a module:
 
-```
+```js
 var hostname = true ? "localhost" : "otherhost";
 
 module.export = {
@@ -83,7 +83,7 @@ export SAUCE_ACCESS_KEY="your-access-key"
 
 Enable SauceLabs in your `.min-wd` file:
 
-```
+```json
 {
   "sauceLabs": true,
   "browsers": [...]
@@ -101,7 +101,7 @@ straight away without loading any web page. If you want to run your test cases
 in the context of a web page, you can configure the start page in the `.min-wd`
 file:
 
-```
+```json
 {
   "url": "http://my-test-page"
 }
@@ -119,27 +119,19 @@ If this is your use case, make sure to give [Mochify][] a try.
 
 ## Timeouts
 
-[Webdriver's session timeouts](https://www.w3.org/TR/webdriver/#set-timeouts)
-are configurable with the `timeouts` property:
+The default timeout for the log polling script is 10 seconds. If you have long
+running test cases that don't print anything for more than 10 seconds, you can
+increase the timeout by adding a `timeout` property to your config:
 
 ```json
-"timeouts": {
-  "script": 10000,
-  "pageLoad": 2000,
-  "implicit": 1000
-}
+"timeout": 20000
 ```
-
-By default only the `script` timeout is set to 10 seconds.
-
-**Notice:** This option is not used if explicitly setting the `asyncPolling`
-option to `false`.
 
 ## API
 
 Use min-wd programatically with browserify like this:
 
-```
+```js
 var browserify = require('browserify');
 var minWd = require('min-wd');
 
@@ -165,12 +157,10 @@ b.plugin(minWd, { timeout : 0 });
     - `name` the name of the browser to launch, e.g. `chrome`, `firefox` or
       `internet explorer`
     - `version` the browser version to launch. Use `*` for any.
-    - `url` an optional URL to launch for this browser
-
-Some options are only considered depending on the `asyncPolling` value:
-
-  - `pollingInterval` sets the time interval between test log checks. Only apply if `asyncPolling` is `false`. Defaults to 1000 milliseconds.
-  - `timeout` option won't apply if `asyncPolling` is set to `false` because the test log is checked manually respecting `pollingInterval`.
+    - `url` an optional URL to launch for this browser.
+- `pollingInterval` sets the time interval between test log checks. Defaults
+  to 100 milliseconds when `asyncPolling = true` or 1000 milliseconds otherwise.
+- `timeout` sets the web driver's `script` and `async_script` timeouts.
 
 SauceLabs specific options that only apply if `sauceLabs` is set to `true`:
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ b.plugin(minWd, { timeout : 0 });
     - `version` the browser version to launch. Use `*` for any.
     - `url` an optional URL to launch for this browser.
 - `pollingInterval` sets the time interval between test log checks. Defaults
-  to 100 milliseconds when `asyncPolling = true` or 1000 milliseconds otherwise.
+  to 100 milliseconds.
 - `timeout` sets the web driver's `script` and `async_script` timeouts.
 
 SauceLabs specific options that only apply if `sauceLabs` is set to `true`:

--- a/lib/client.js
+++ b/lib/client.js
@@ -11,8 +11,10 @@
 var brout   = require('brout');
 var logs    = [];
 var pending = null;
+var flushTimeout = null;
 
 function flush() {
+  clearTimeout(flushTimeout);
   pending(logs.join(''));
   logs.length = 0;
   pending = null;
@@ -26,6 +28,7 @@ function push(str) {
 }
 
 window._webdriver_poll = function (callback) {
+  flushTimeout = setTimeout(flush, 5000);
   pending = callback;
   if (logs.length) {
     flush();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -209,10 +209,6 @@ function connectBrowser(context, callback) {
       return;
     }
 
-    var timeouts = context.timeouts || {
-      script: context.timeout || 10000
-    };
-
     setDriverTimeouts(context, context.timeout || 10000, function (err) {
       if (err) {
         handleError(context, err, callback);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -34,7 +34,7 @@ function handleError(context, err, callback) {
 
 function pollLogs(context, callback) {
   var endpoint = context.asyncPolling ? '/execute_async' : '/execute';
-  var timeout = context.pollingInterval || 0;
+  var timeout = context.pollingInterval;
   var script;
   if (context.asyncPolling) {
     script = 'window._webdriver_poll(arguments[0]);';

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -34,8 +34,7 @@ function handleError(context, err, callback) {
 
 function pollLogs(context, callback) {
   var endpoint = context.asyncPolling ? '/execute_async' : '/execute';
-  var timeout = context.pollingInterval ? context.pollingInterval
-    : context.asyncPolling ? 100 : 0;
+  var timeout = context.pollingInterval || 0;
   var script;
   if (context.asyncPolling) {
     script = 'window._webdriver_poll(arguments[0]);';

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -7,12 +7,12 @@
  */
 'use strict';
 
-var through   = require('through2');
-var listen    = require('listen');
-var sourceMap = require('source-mapper');
-var request   = require('./request');
-var sauceLabs = require('./saucelabs');
-
+var through           = require('through2');
+var listen            = require('listen');
+var sourceMap         = require('source-mapper');
+var request           = require('./request');
+var setDriverTimeouts = require('./set-driver-timeouts');
+var sauceLabs         = require('./saucelabs');
 
 function close(context, callback) {
   request(context, 'DELETE', "/window", null, function () {
@@ -207,9 +207,12 @@ function connectBrowser(context, callback) {
       callback(null);
       return;
     }
-    request(context, 'POST', '/timeouts/async_script', {
-      ms : context.timeout || 10000
-    }, function (err) {
+
+    var timeouts = context.timeouts || {
+      script: context.timeout || 10000
+    };
+
+    setDriverTimeouts(context, timeouts, function (err) {
       if (err) {
         handleError(context, err, callback);
       } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -212,7 +212,7 @@ function connectBrowser(context, callback) {
       script: context.timeout || 10000
     };
 
-    setDriverTimeouts(context, timeouts, function (err) {
+    setDriverTimeouts(context, context.timeout || 10000, function (err) {
       if (err) {
         handleError(context, err, callback);
       } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -34,7 +34,8 @@ function handleError(context, err, callback) {
 
 function pollLogs(context, callback) {
   var endpoint = context.asyncPolling ? '/execute_async' : '/execute';
-  var timeout = context.asyncPolling ? 0 : context.pollingInterval;
+  var timeout = context.pollingInterval ? context.pollingInterval
+    : context.asyncPolling ? 100 : 0;
   var script;
   if (context.asyncPolling) {
     script = 'window._webdriver_poll(arguments[0]);';

--- a/lib/options.js
+++ b/lib/options.js
@@ -48,7 +48,7 @@ module.exports = function (opts) {
       name        : 'chrome'
     }],
     asyncPolling : true,
-    pollingInterval : 1000,
+    pollingInterval : 100,
     closeOnError  : true,
     closeOnSuccess : true
   };

--- a/lib/set-driver-timeouts.js
+++ b/lib/set-driver-timeouts.js
@@ -5,16 +5,15 @@ var request = require('./request');
 
 module.exports = function (ctx, timeout, cb) {
   var listener = listen();
-  var type;
 
   request(ctx, "POST", "/timeouts", {
     type: "script",
     ms: timeout
-  }, listener(type));
+  }, listener());
 
   request(ctx, "POST", "/timeouts/async_script", {
     ms: timeout
-  }, listener(type));
+  }, listener());
 
   listener.then(cb);
 };

--- a/lib/set-driver-timeouts.js
+++ b/lib/set-driver-timeouts.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var listen = require('listen');
+var request = require('./request');
+
+module.exports = function (ctx, timeouts, cb) {
+  var listener = listen();
+  var type;
+
+  for (type in timeouts) {
+    if (timeouts.hasOwnProperty(type)) {
+      request(ctx, "POST", "/timeouts", {
+        type: type,
+        ms: timeouts[type]
+      }, listener);
+    }
+  }
+
+  listen.then(cb);
+};

--- a/lib/set-driver-timeouts.js
+++ b/lib/set-driver-timeouts.js
@@ -3,18 +3,18 @@
 var listen = require('listen');
 var request = require('./request');
 
-module.exports = function (ctx, timeouts, cb) {
+module.exports = function (ctx, timeout, cb) {
   var listener = listen();
   var type;
 
-  for (type in timeouts) {
-    if (timeouts.hasOwnProperty(type)) {
-      request(ctx, "POST", "/timeouts", {
-        type: type,
-        ms: timeouts[type]
-      }, listener(type));
-    }
-  }
+  request(ctx, "POST", "/timeouts", {
+    type: "script",
+    ms: timeout
+  }, listener(type));
+
+  request(ctx, "POST", "/timeouts/async_script", {
+    ms: timeout
+  }, listener(type));
 
   listener.then(cb);
 };

--- a/lib/set-driver-timeouts.js
+++ b/lib/set-driver-timeouts.js
@@ -12,9 +12,9 @@ module.exports = function (ctx, timeouts, cb) {
       request(ctx, "POST", "/timeouts", {
         type: type,
         ms: timeouts[type]
-      }, listener);
+      }, listener(type));
     }
   }
 
-  listen.then(cb);
+  listener.then(cb);
 };


### PR DESCRIPTION
Replaced the `async_script` with all possible available timeouts defined at https://www.w3.org/TR/webdriver/#set-timeouts. I am not sure if I understood everything right but it looks like async_script is not supported?

On top of that I've introduced periodic log flushing.

`npm test` is green :) but I'll test this next week on a project once I'll be back from vacations. Till then, let me know if you see anything obviously wrong.