### PR TITLE
Fix example in readme for loading .min-wd file as module

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can also have the `.min-wd` file be loaded as a module:
 ```
 var hostname = true ? "localhost" : "otherhost";
 
-module.export = {
+module.exports = {
   "hostname": hostname,
   "port": 4444,
   "browsers": [{


### PR DESCRIPTION
I am not sure if `module.export` is supposed to work in some situations, but only `module.exports` works for me with Node v10.3.0.